### PR TITLE
Make postrm use bash’s hashbang

### DIFF
--- a/postrm
+++ b/postrm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 arrBundles=(/Library/ControlCenter/Bundles/*)
 for ((i=0; i<${#arrBundles[@]}; i++)); do
     if [ -f ${arrBundles[$i]}/flag_ported_flipconvert ]; then


### PR DESCRIPTION
This will fix the script when /bin/sh isn’t bash. I would also recommend adding `Depends: bash` to the control file.